### PR TITLE
Add plant care notifications and refactor localization

### DIFF
--- a/api/src/main/java/eu/germanrp/addon/api/models/PlantHeilkraut.java
+++ b/api/src/main/java/eu/germanrp/addon/api/models/PlantHeilkraut.java
@@ -8,8 +8,8 @@ import org.jetbrains.annotations.NotNull;
 @Setter
 public non-sealed class PlantHeilkraut extends Plant {
 
-  private static final int FERTILIZE_TIME = 4;
-  private static final int WATER_TIME = 10;
+  public static final int FERTILIZE_TIME = 4;
+  public static final int WATER_TIME = 10;
 
   private boolean fertilized = false;
   private boolean watered = false;

--- a/core/src/main/java/eu/germanrp/addon/core/listener/PlantListener.java
+++ b/core/src/main/java/eu/germanrp/addon/core/listener/PlantListener.java
@@ -10,6 +10,8 @@ import eu.germanrp.addon.core.Utils;
 import eu.germanrp.addon.core.widget.HeilkrautpflanzeHudWidget;
 import eu.germanrp.addon.core.widget.RoseHudWidget;
 import eu.germanrp.addon.core.widget.StoffHudWidget;
+import net.labymod.api.client.component.Component;
+import net.labymod.api.client.component.format.TextColor;
 import net.labymod.api.event.Subscribe;
 import net.labymod.api.event.client.chat.ChatReceiveEvent;
 import net.labymod.api.event.client.network.server.NetworkPayloadEvent;
@@ -19,11 +21,18 @@ import net.labymod.api.util.GsonUtil;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static eu.germanrp.addon.api.models.PlantHeilkraut.FERTILIZE_TIME;
+import static eu.germanrp.addon.api.models.PlantHeilkraut.WATER_TIME;
+
 public class PlantListener {
 
     private static final Pattern HARVEST_PATTERN = Pattern.compile(
             "^► Du hast \\S* (\\S+) mit \\d+(?: Stück|x|g)? Erlös geerntet\\.$", Pattern.CANON_EQ);
     private static final String PLANT_DIED_MESSAGE = "► Du hast deine Pflanze nicht rechtzeitig geerntet.";
+    public static final String HEILKRAUT_FERTILIZE_MESSAGE = "germanrputils.message.plant.heilkrautpflanze.fertilize";
+    public static final String HEILKRAUT_WATER_MESSAGE = "germanrputils.message.plant.heilkrautpflanze.water";
+    public static final String PLANT_HARVEST_MESSAGE = "germanrputils.message.plant.harvest";
+    public static final TextColor NOTIFICATION_COLOR = TextColor.color(0x75, 0x15, 0x1E);
 
     private final GRUtilsAddon addon;
     private final HeilkrautpflanzeHudWidget heilkrautpflanzeHudWidget;
@@ -87,6 +96,28 @@ public class PlantListener {
                 case HEILKRAUTPFLANZE -> this.heilkrautpflanzeHudWidget.onPaketReceive(plantPaket);
                 case ROSE -> this.roseHudWidget.onPaketReceive(plantPaket);
                 case STOFF -> this.stoffHudWidget.onPaketReceive(plantPaket);
+            }
+
+            if (plantPaket.getCurrentTime() == plantPaket.getMaxTime()) {
+                addon.displayMessage(Component.translatable(
+                                PLANT_HARVEST_MESSAGE,
+                                Component.text(plantPaket.getType().getDisplayName())
+                        )
+                        .color(NOTIFICATION_COLOR));
+            }
+
+            if (plantPaket.getType() != PlantType.HEILKRAUTPFLANZE) {
+                return;
+            }
+
+            if (plantPaket.getCurrentTime() == FERTILIZE_TIME && plantPaket.isActive()) {
+                addon.displayMessage(Component.translatable(HEILKRAUT_FERTILIZE_MESSAGE)
+                        .color(NOTIFICATION_COLOR));
+            }
+
+            if (plantPaket.getCurrentTime() == WATER_TIME && plantPaket.isActive()) {
+                addon.displayMessage(Component.translatable(HEILKRAUT_WATER_MESSAGE)
+                        .color(NOTIFICATION_COLOR));
             }
 
         });

--- a/core/src/main/resources/assets/germanrputils/i18n/en_us.json
+++ b/core/src/main/resources/assets/germanrputils/i18n/en_us.json
@@ -103,33 +103,13 @@
         }
       }
     },
-    "hudWidget": {
-      "heilkrautpflanze": {
-        "name": "Heilkraut-\npflanze",
-        "showTimer.name": "Timer",
-        "showYield.name": "Erlös"
-      },
-      "rose": {
-        "name": "Rose",
-        "showTimer.name": "Timer",
-        "showYield.name": "Erlös"
-      },
-      "stoff": {
-        "name": "Stoffpflanze",
-        "showTimer.name": "Timer",
-        "showYield.name": "Erlös"
-      }
-    },
-    "widget": {
-      "category": {
-        "title": "GermanRP",
-        "description": "Shows you information about stuff on GermanRP"
-      },
+    "message": {
       "plant": {
-        "progressKey": "Fortschritt",
-        "progressValue": "%s/%smin",
-        "yieldKey": "Erlös",
-        "yieldValue": "%s%s %s"
+        "heilkrautpflanze": {
+          "fertilize": "Du musst deine Heilkrautpflanze jetzt düngen.",
+          "water": "Du musst deine Heilkrautpflanze jetzt wässern."
+        },
+        "harvest": "%s kann geerntet werden."
       }
     },
     "hudWidget": {


### PR DESCRIPTION
Introduced new notifications for fertilizing, watering, and harvesting plants. Refactored localization strings to improve message clarity and reduced redundant HUD widget entries. Made `FERTILIZE_TIME` and `WATER_TIME` constants public for wider accessibility.