### PR TITLE
Add nightly build and release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       run: ./gradlew build --full-stacktrace
 
     - name: Upload Build Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@4.6.2
       with:
         name: germanrp-addon-release
         path: build/libs/germanrp-addon-release.jar
@@ -64,7 +64,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@4.3.0
         with:
           name: germanrp-addon-release
           path: ./artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,15 +35,22 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
-    - name: Build with Gradle (Nightly)
+    - name: Set Build Version
       if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+      run: |
+        VERSION=nightly-$(git rev-parse --short HEAD)
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+    - name: Build with Gradle
       env:
-        VERSION: nightly
+        VERSION: $ {{ env.VERSION }}
       run: ./gradlew build --full-stacktrace
 
-    - name: Build with Gradle (Regular)
-      if: ${{ github.event_name == 'pull_request' }}
-      run: ./gradlew build --full-stacktrace
+    - name: Upload Build Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: germanrp-addon-release
+        path: build/libs/germanrp-addon-release.jar
 
   release:
 
@@ -56,6 +63,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: germanrp-addon-release
+          path: ./artifacts
+
       - name: Create a Nightly Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -66,4 +79,5 @@ jobs:
             --title "$RELEASE_NAME" \
             --notes "Hinweis: Dies ist ein Nightly-Build. Dieser Build wird automatisch generiert und kann Fehler enthalten oder nicht ordnungsgemäß funktionieren." \
             --prerelease \
-            --target develop
+            --target develop \
+            ./artifacts/germanrp-addon-release.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,10 @@ name: Build
 on:
   pull_request:
     branches: [ "main", "develop" ]
+  schedule:
+    - cron: "55 1 * * *" # 5 Minutes before Server restart
+  workflow_dispatch:
+
 
 run-name: Build+${{ github.run_number }} build/${{ github.sha }}
 
@@ -31,5 +35,35 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
-    - name: Build with Gradle
+    - name: Build with Gradle (Nightly)
+      if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+      env:
+        VERSION: nightly
       run: ./gradlew build --full-stacktrace
+
+    - name: Build with Gradle (Regular)
+      if: ${{ github.event_name == 'pull_request' }}
+      run: ./gradlew build --full-stacktrace
+
+  release:
+
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    name: 🚀 Nightly Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create a Nightly Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME="nightly"
+          RELEASE_NAME="Nightly Build - $(date -u +"%Y-%m-%d %H:%M:%S")"
+          gh release create "$TAG_NAME" \
+            --title "$RELEASE_NAME" \
+            --notes "Hinweis: Dies ist ein Nightly-Build. Dieser Build wird automatisch generiert und kann Fehler enthalten oder nicht ordnungsgemäß funktionieren." \
+            --prerelease \
+            --target develop


### PR DESCRIPTION
Introduce a scheduled and manual nightly build process triggered via cron and `workflow_dispatch`. Included automatic creation of nightly releases for the `develop` branch with appropriate tagging and pre-release notes.